### PR TITLE
Algorithm changes

### DIFF
--- a/src/scripts/Fetchers/Fetcher.js
+++ b/src/scripts/Fetchers/Fetcher.js
@@ -3,6 +3,10 @@
  * Fetcher class that will be subclassed by the different fetchers
  */
 export class Fetcher {
+    constructor(container){
+        this.container = container
+    }
+
     async fetchPosts() {
         throw new Error("Not implemented - You must implement fetchPosts() in a subclass");
     }

--- a/src/scripts/Fetchers/LemmyFetcher.js
+++ b/src/scripts/Fetchers/LemmyFetcher.js
@@ -15,12 +15,10 @@ export class LemmyFetcher extends Fetcher {
                 throw new Error(`HTTP error: ${response.status}`);
             }
             let response_data = await response.json();
-            let posts = []
             const posts_json = response_data.posts
             posts_json.forEach(post => {
-                posts.push(this.#createPost(post))
+                this.container.appendChild(this.#createPost(post))
             });
-            return posts
         } catch (error) {
             console.error(`Failed to fetch trending posts:`, error);
             return null;

--- a/src/scripts/Fetchers/LemmyFetcher.js
+++ b/src/scripts/Fetchers/LemmyFetcher.js
@@ -6,7 +6,8 @@ export class LemmyFetcher extends Fetcher {
 
     /**
      * 
-     * @returns {Promise<Array>} - A promise that resolves to an array of Post elements
+     * Fetches trending posts from Lemmy API and displays them using custom fedi-post HTML element
+     * Webpage container is directly updated to reduce response time
      */
     async fetchPosts() {
         try {

--- a/src/scripts/Fetchers/MastodonFetcher.js
+++ b/src/scripts/Fetchers/MastodonFetcher.js
@@ -20,8 +20,8 @@ function interleaveArrays(responses) {
 export class MastodonFetcher extends Fetcher {
   
   /**
-   * 
-   * @returns {Promise<Array>} - A promise that resolves to an array of Post elements
+   * Fetches trending tags and displays posts for each tag in an interleaved manner
+   * Webpage container is directly updated to reduce response time
    */
   async fetchPosts() {
     const hashtags = await this.#fetchTrendingTagsMastodon(MASTODON_SOCIAL_TRENDING_TAGS);

--- a/src/scripts/Fetchers/MastodonFetcher.js
+++ b/src/scripts/Fetchers/MastodonFetcher.js
@@ -1,6 +1,22 @@
 import {Fetcher} from "./Fetcher.js";
 import {MASTODON_SOCIAL_TRENDING_POST_PER_TAG, MASTODON_SOCIAL_TRENDING_TAGS} from "../consts.js";
 
+function interleaveArrays(responses) {
+  const maxLength = Math.max(...responses.map(response => response.length));
+  const result = [];
+
+  for (let i = 0; i < maxLength; i++) {
+    for (let j = 0; j < responses.length; j++) {
+      if (responses[j].length > i) {
+        result.push(responses[j][i]);
+      }
+    }
+  }
+
+  return result;
+}
+
+
 export class MastodonFetcher extends Fetcher {
   
   /**
@@ -10,17 +26,18 @@ export class MastodonFetcher extends Fetcher {
   async fetchPosts() {
     const hashtags = await this.#fetchTrendingTagsMastodon(MASTODON_SOCIAL_TRENDING_TAGS);
     let json_posts = [];
+    let responses = [];
     for (const tag of hashtags) {
       let response = await this.#fetchPostsByHashtagMastodon(tag.name);
-      for (let i = 0; i < response.length; i++) {
-        json_posts.push(response[i]);
-      }
+      responses.push(response);
+      this.container.appendChild(this.#createNewMastodonPost(response[0]))  // Add atleast one response now only before loading all the jsons
     }
-    let posts = [];
-    json_posts.forEach(post => {
-      posts.push(this.#createNewMastodonPost(post));
+
+    let results = interleaveArrays(responses);
+
+    results.forEach(json_post => {
+      this.container.appendChild(this.#createNewMastodonPost(json_post));
     });
-    return posts;
   }
 
   /**

--- a/src/scripts/index.js
+++ b/src/scripts/index.js
@@ -11,12 +11,6 @@ document.addEventListener("DOMContentLoaded", function () {
  */
 async function displayPostsNew() {
     const container = document.getElementById("featuredTagsPosts");
-    const postFetcher = new PostFetcher();
-    const posts = await postFetcher.fetchPosts();
-    
-    // Display posts
-    posts.forEach(post => {
-        container.appendChild(post);
-    });
-
+    const postFetcher = new PostFetcher(container);
+    await postFetcher.fetchPosts();
 }

--- a/src/scripts/postsFetcher.js
+++ b/src/scripts/postsFetcher.js
@@ -6,18 +6,16 @@ import {MastodonFetcher} from "./Fetchers/MastodonFetcher.js";
  * Main function to fetch posts from various instances.
  */
 export class PostFetcher {
-    constructor(){
+    constructor(container){
+        this.container = container
         this.fetchers = []
-        this.fetchers.push(new LemmyFetcher())
-        this.fetchers.push(new MastodonFetcher())
+        this.fetchers.push(new LemmyFetcher(container))
+        this.fetchers.push(new MastodonFetcher(container))
     }
 
     async fetchPosts(){
-        let posts = []
         for (const fetcher of this.fetchers) {
-            let new_posts = await fetcher.fetchPosts()
-            posts.push(...new_posts)
+            await fetcher.fetchPosts()
         }
-        return posts
     }
 }

--- a/test/scripts/Fetchers/LemmyFetcher.js
+++ b/test/scripts/Fetchers/LemmyFetcher.js
@@ -12,10 +12,13 @@ global.document = window.document;
 describe('LemmyFetcher', () => {
 
     let fetchStub;
+    let lemmyFetcher;
 
     beforeEach(() => {
         // Create a stub for the global fetch
         fetchStub = sinon.stub(global, 'fetch');
+        lemmyFetcher = new LemmyFetcher();
+        lemmyFetcher.container = global.document.createElement('div');
     });
 
     describe('#fetchPosts', () => {
@@ -42,8 +45,9 @@ describe('LemmyFetcher', () => {
         // Pass the mock response to the fetch stub
         fetchStub.resolves(mockResponse);
    
-        const lemmyFetcher = new LemmyFetcher();
-        const posts = await lemmyFetcher.fetchPosts();
+        await lemmyFetcher.fetchPosts();
+
+        const posts = lemmyFetcher.container.querySelectorAll('fedi-post');
    
         assert.strictEqual(posts.length, 2);
         assert.strictEqual(posts[0].getAttribute('id'), '1');


### PR DESCRIPTION
1. Callback added to Fetcher class to directly add the posts to the container, instead of waiting for all the jsons to load 
2. Mastodon posts are shown interleaved instead of all the posts from a certain trending tag first and then next.

Pros:
1. Response time is much better
2. Results are shown interleaved so user gets different posts trending in different tags.

Cons:
Because of interleaving, possible higher memory usage if the garbage collector can be made to work efficiently to remove the jsons.

Note: Sorry, in case style of coding is different, let me know if those changes are needed.